### PR TITLE
Zpp new web3 version + minor optimizations

### DIFF
--- a/backend/common/settings.js
+++ b/backend/common/settings.js
@@ -4,6 +4,10 @@ module.exports.ETHEROSCOPEMICROSERVICE=process.env.ETHEROSCOPEMICROSERVICE
 module.exports.ETHEROSCOPESERVER=process.env.ETHEROSCOPESERVER
 module.exports.ETHEROSCOPEFRONTEND=process.env.ETHEROSCOPEFRONTEND
 
+module.exports.server = {
+  etherscanAPIKey: "RVDWXC49N3E3RHS6BX77Y24F6DFA8YTK23",
+}
+
 module.exports.dataPointsService = {
   cacheChunkSize: 10000,
   socketPort: 8081

--- a/backend/data-points-service/dataPointsSender.js
+++ b/backend/data-points-service/dataPointsSender.js
@@ -48,8 +48,9 @@ module.exports = function (io, log) {
          *
          * @param {string} address
          * @param {string} variableName
+         * @param {string} socketId
          */
-        dataPointsSender.sendHistory = async function (address, variableName) {
+        dataPointsSender.sendHistory = async function (address, variableName, socketId) {
             try {
                 log.debug(`dataPointsSender.sendHistory ${address} ${variableName}`)
 
@@ -62,11 +63,11 @@ module.exports = function (io, log) {
                 if (curLatestBlock) {
                     io.sockets.in(address + variableName).emit('latestBlock', {latestBlock: curLatestBlock})
 
-                    await sendAllDataPointsFromDB(address, variableName, cachedFrom, cachedUpTo)
+                    await sendAllDataPointsFromDB(address, variableName, cachedFrom, cachedUpTo, socketId)
                 } else {
                     io.sockets.in(address + variableName).emit('latestBlock', {latestBlock: latestBlock})
 
-                    await sendAllDataPointsFromDB(address, variableName, cachedFrom, cachedUpTo)
+                    await sendAllDataPointsFromDB(address, variableName, cachedFrom, cachedUpTo, socketId)
 
                     let contractInfo = await parityClient.getContract(address)
 
@@ -88,8 +89,9 @@ module.exports = function (io, log) {
          * @param {string} variableName
          * @param {Number} from
          * @param {Number} to
+         * @param {String} socketId
          */
-        async function sendAllDataPointsFromDB(address, variableName, from, to) {
+        async function sendAllDataPointsFromDB(address, variableName, from, to, socketId) {
             try {
                 log.debug(`dataPointsSender.sendAllDataPointsFromDB ${address} ${variableName} ${from} ${to}`)
 
@@ -98,7 +100,7 @@ module.exports = function (io, log) {
                 let new_dataPoints = dataPoints.map(dataPoint =>
                     [dataPoint.Block.timeStamp, dataPoint.value, dataPoint.Block.number])
 
-                io.sockets.in(address + variableName).emit('getHistoryResponse', {
+                io.to(socketId).emit('getHistoryResponse', {
                     error: false,
                     from: from,
                     to: to,

--- a/backend/data-points-service/dataPointsSender.js
+++ b/backend/data-points-service/dataPointsSender.js
@@ -1,5 +1,3 @@
-const Promise = require('bluebird')
-
 const errorHandler = require('../common/errorHandlers')
 const Parity = require('../common/parity')
 const streamedSet = require('./streamedSet')()
@@ -28,7 +26,7 @@ module.exports = function (io, log) {
         function setInitCached(cachedRange) {
             let {cachedFrom, cachedUpTo} = cachedRange
 
-            if (cachedUpTo == null || cachedUpTo === null)
+            if (cachedUpTo == null || cachedFrom === null)
                 return {
                     cachedFrom: 1,
                     cachedUpTo: 0
@@ -96,8 +94,10 @@ module.exports = function (io, log) {
                 log.debug(`dataPointsSender.sendAllDataPointsFromDB ${address} ${variableName} ${from} ${to}`)
 
                 let dataPoints = await db.getDataPoints(address.substr(2), variableName)
-                let new_dataPoints = []
-                dataPoints.forEach(dataPoint => (new_dataPoints.push([dataPoint.Block.timeStamp, dataPoint.value, dataPoint.Block.number])))
+                dataPoints = dataPoints == null ? [] : dataPoints
+                let new_dataPoints = dataPoints.map(dataPoint =>
+                    [dataPoint.Block.timeStamp, dataPoint.value, dataPoint.Block.number])
+
                 io.sockets.in(address + variableName).emit('getHistoryResponse', {
                     error: false,
                     from: from,

--- a/backend/data-points-service/dataPointsService.js
+++ b/backend/data-points-service/dataPointsService.js
@@ -42,7 +42,7 @@ io.on('connection', function (socket) {
             let room = address + varableName
             log.debug(`Joining room ${room}`)
             socket.join(room)
-            dataPointsSender.sendHistory(address, varableName)
+            dataPointsSender.sendHistory(address, varableName, socket.id)
         } catch (err) {
             log.error('dataPointsService connection', err)
         }

--- a/backend/package.json
+++ b/backend/package.json
@@ -83,6 +83,7 @@
     "loglevel": "^1.6.0",
     "mssql": "^4.1.0",
     "mutationobserver-shim": "^0.3.2",
+    "mysql2": "^1.6.4",
     "ng-socket-io": "^0.2.0",
     "ng2-select-compat": "^1.3.1",
     "node-sass": "^4.7.2",
@@ -90,18 +91,17 @@
     "rlp": "^2.1.0",
     "rwlock": "^5.0.0",
     "rxjs": "^5.5.2",
+    "sequelize": "^4.42.0",
     "socket.io": "^2.0.4",
     "spinkit": "^1.2.5",
+    "sqlite3": "^3.1.3",
     "standard": "^10.0.3",
     "ts-clipboard": "^1.0.15",
     "ts-helpers": "^1.1.2",
     "validator": "^9.1.1",
     "web-animations-js": "^2.3.1",
-    "web3": "^0.19.0",
+    "web3": "^1.0.0-beta.51",
     "webpack-sources": "^1.0.1",
-    "zone.js": "^0.8.18",
-    "mysql2": "^1.6.4",
-    "sequelize": "^4.42.0",
-    "sqlite3": "^3.1.3"
+    "zone.js": "^0.8.18"
   }
 }


### PR DESCRIPTION
General changes:
1. updated web3 version
2. optimized parity.getHistory function
3. changed parity.getContractInfoFromEtherscan, so now we also retrieve contract's name from Etherscan API
4. datapoints already saved in database are sent to particular client instead of broadcasting to all of them (up to now frontend had to deal with issue of repeating data)

Files:
1. parity.js -> changed web3 calls to compatible with new version of library, optimized parity.getHistory and added retrieving contract's name from Etherscan API
2. settings.js -> moved etherscanAPIKey to settings
5. dataPointsSender -> sending data stored in database directly to particular client, replaced unnecessary appends with map
4. dataPointsService.js -> socket.id has to be passed in order to send data to particular client
3. package.json -> new web3 version